### PR TITLE
Support p2p comm for local platform

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ tensorflow==1.15.2
 keras==2.2.5
 scikit-learn
 flask
-git+https://github.com/IBM/pycloudmessenger/archive/v0.3.0.tar.gz
+https://github.com/IBM/pycloudmessenger/archive/v0.3.0.tar.gz


### PR DESCRIPTION
Solve issue #44 in Pycloudmessenger repo: https://github.com/IBM/pycloudmessenger/issues/44.
- Add the option of sending a message to a specific user from the aggregator to local platform.